### PR TITLE
Fix shortened FQDN

### DIFF
--- a/templates/etc/grid-security/grid-mapfile.erb
+++ b/templates/etc/grid-security/grid-mapfile.erb
@@ -15,7 +15,7 @@
     @capability1 = "Capability=NULL"
     @capability2 = ""
   else
-    @capability1 = "Capability=#{capability}"
+    @capability1 = "Capability=#{@capability}"
     @capability2 = @capability1
   end
 -%>

--- a/templates/etc/grid-security/grid-mapfile.erb
+++ b/templates/etc/grid-security/grid-mapfile.erb
@@ -12,10 +12,10 @@
   end
   @capability=pool['capability']
   if @capability == nil
-    @capability1 = "Capability=NULL"
+    @capability1 = "/Capability=NULL"
     @capability2 = ""
   else
-    @capability1 = "Capability=#{@capability}"
+    @capability1 = "/Capability=#{@capability}"
     @capability2 = @capability1
   end
 -%>

--- a/templates/etc/grid-security/grid-mapfile.erb
+++ b/templates/etc/grid-security/grid-mapfile.erb
@@ -4,15 +4,23 @@
   @pool_name=pool['name']
   @role=pool['role']
   if @role == nil
-    @role = "NULL"
+    @role1 = "/Role=NULL"
+    @role2 = ""
+  else
+    @role1 = "/Role=#{@role}"
+    @role2 = @role1
   end
   @capability=pool['capability']
   if @capability == nil
-    @capability = "NULL"
+    @capability1 = "Capability=NULL"
+    @capability2 = ""
+  else
+    @capability1 = "Capability=#{capability}"
+    @capability2 = @capability1
   end
 -%>
-"/<%=@vo_name%>/Role=<%=@role%>/Capability=<%=@capability%>" .<%=@pool_name%>
-"/<%=@vo_name%>" .<%=@pool_name%>
+"/<%=@vo_name%><%=@role1%><%=@capability1%>" .<%=@pool_name%>
+"/<%=@vo_name%><%=@role2%><%=@capability2%>" .<%=@pool_name%>
 <%- 
 end
 -%>

--- a/templates/etc/grid-security/groupmapfile.erb
+++ b/templates/etc/grid-security/groupmapfile.erb
@@ -15,7 +15,7 @@
     @capability1 = "Capability=NULL"
     @capability2 = ""
   else
-    @capability1 = "Capability=#{capability}"
+    @capability1 = "Capability=#{@capability}"
     @capability2 = @capability1
   end
 -%>

--- a/templates/etc/grid-security/groupmapfile.erb
+++ b/templates/etc/grid-security/groupmapfile.erb
@@ -4,15 +4,23 @@
   @group=pool['group']
   @role=pool['role']
   if @role == nil
-    @role = "NULL"
+    @role1 = "/Role=NULL"
+    @role2 = ""
+  else
+    @role1 = "/Role=#{@role}"
+    @role2 = @role1
   end
   @capability=pool['capability']
   if @capability == nil
-    @capability = "NULL"
+    @capability1 = "Capability=NULL"
+    @capability2 = ""
+  else
+    @capability1 = "Capability=#{capability}"
+    @capability2 = @capability1
   end
 -%>
-"/<%=@vo_name%>/Role=<%=@role%>/Capability=<%=@capability%>" <%=@group%>
-"/<%=@vo_name%>" <%=@group%>
+"/<%=@vo_name%><%=@role1%><%=@capability1%>" <%=@group%>
+"/<%=@vo_name%><%=@role2%><%=@capability2%>" <%=@group%>
 <%- 
 end
 -%>

--- a/templates/etc/grid-security/groupmapfile.erb
+++ b/templates/etc/grid-security/groupmapfile.erb
@@ -12,10 +12,10 @@
   end
   @capability=pool['capability']
   if @capability == nil
-    @capability1 = "Capability=NULL"
+    @capability1 = "/Capability=NULL"
     @capability2 = ""
   else
-    @capability1 = "Capability=#{@capability}"
+    @capability1 = "/Capability=#{@capability}"
     @capability2 = @capability1
   end
 -%>


### PR DESCRIPTION
In _grid-mapfile_ and _groupmapfile_, the module strips the second entry of each group down to the VO name, producing something like this:
```
"/atlas/Role=lcgadmin/Capability=NULL" .sgmatlas
"/atlas" .sgmatlas
"/atlas/Role=production/Capability=NULL" .prdatlas
"/atlas" .prdatlas
"/atlas/Role=pilot/Capability=NULL" .pilatlas
"/atlas" .pilatlas
"/atlas/Role=NULL/Capability=NULL" .atlas
"/atlas" .atlas
```
Note that the `"/atlas"` pattern is repeated several times.

On the contrary, this is how the file looks like in the old, _yaim_ managed servers:
```
"/atlas/Role=lcgadmin/Capability=NULL" .sgmatlas
"/atlas/Role=lcgadmin" .sgmatlas
"/atlas/Role=production/Capability=NULL" .prdatlas
"/atlas/Role=production" .prdatlas
"/atlas/Role=pilot/Capability=NULL" .pilatlas
"/atlas/Role=pilot" .pilatlas
"/atlas/Role=NULL/Capability=NULL" .atlas
"/atlas" .atlas
```
I haven't found an authoritative source, but my guess is that the second form is correct, i.e. only the NULL fields should be removed.

P.S. the attached recipe should be improved in order to avoid duplicated entries when no fields are NULL (never seen that in any VO yet, though)...
